### PR TITLE
fix yaml-cpp linking in cmake

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 target_link_libraries(hard
 	Spec::Spec
 	FleCSI::FleCSI
-	yaml-cpp
+	yaml-cpp::yaml-cpp
 )
 
 


### PR DESCRIPTION
Without this fix cmake might fail to produce the right linker flags to pick up yaml-cpp installed in nonstandard location, such as with spack.