### PR TITLE
Turn off benchmark mode by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ mark_as_advanced(HARD_WRITE_CONTROL_INFO)
 #------------------------------------------------------------------------------#
 
 option(HARD_BENCHMARK_MODE
-  "Benchmark mode disables I/O and adds time measurement" ON)
+  "Benchmark mode disables I/O and adds time measurement" OFF)
 mark_as_advanced(HARD_BENCHMARK_MODE)
 
 #------------------------------------------------------------------------------#


### PR DESCRIPTION
As a physics application, it is preferable to have the benchmark mode switched on by demand, not by default.