### PR TITLE
Fix distributed CSV comparison test

### DIFF
--- a/tools/test_distributed.sh
+++ b/tools/test_distributed.sh
@@ -12,15 +12,12 @@ export HPX_COMMANDLINE_OPTIONS="--hpx:threads=2"
 
 # Run the executable twice
 rm -f *.csv
-ls
 echo "Starting.."
 OMP_NUM_THREADS=1 "$mpi_executable" -np 1 "$hard_executable" "$config_file" $additional_args
 echo "Mid..."
 # rename before getting overwritten by next command
 mv output-*-0-00002.csv r1.csv
-ls
 OMP_NUM_THREADS=1 "$mpi_executable" -np 16 "$hard_executable" "$config_file" $additional_args
-ls
 
 
 # Stitch together 16 csv outputs to 1 (mp.csv)
@@ -28,11 +25,11 @@ ls
 
 for i in {0..15}; do
     # Exclude header and first 3 columns
-    sed '1d;/^$/d' "output-1D-${i}-00002.csv"  | awk 'BEGIN {FS="\t"; OFS="\t"} {print $4, $5, $6, $7}' >> mp.csv
+    sed '1d;/^$/d' "output-1D-${i}-00002.csv"  | awk 'BEGIN {FS=","; OFS=","} {print $4, $5, $6, $7}' >> mp.csv
 done
 
 # Create a temporary version of r1.csv excluding the header lines
-sed '1d;/^$/d' r1.csv  | awk 'BEGIN {FS="\t"; OFS="\t"} {print $4, $5, $6, $7}' > r1_temp.csv
+sed '1d;/^$/d' r1.csv  | awk 'BEGIN {FS=","; OFS=","} {print $4, $5, $6, $7}' > r1_temp.csv
 
 set +e
 diff mp.csv r1_temp.csv > /dev/null
@@ -44,12 +41,12 @@ if [ $exit_status -eq 0 ]; then
 else
     echo "Files are different."
     set +e
-    diff mp.csv r1_temp.csv
+    diff -u mp.csv r1_temp.csv
     set -e
 fi
 
 # Clean up temporary files
-rm *.csv
+rm -f *.csv
 
 # Exit with the status from diff (0 for no differences, 1 for differences)
 exit $exit_status


### PR DESCRIPTION
## Summary
- Compare distributed test CSV output using comma delimiters.
- Remove noisy directory listings from the test script.
- Show a unified diff when the single-rank and distributed outputs differ.
- Use tolerant cleanup for generated CSV files.

## Testing
- `bash -n tools/test_distributed.sh`
- `git diff --check`
- Tried configuring the full HARD test build in WSL with `cmake -S . -B build -G Ninja -DENABLE_UNIT_TESTS=ON -DENABLE_VERIFICATION=ON`. Configure stopped because FleCSI is not installed in my local WSL environment.