### PR TITLE
Fix flecsolve Spack branch

### DIFF
--- a/spack-repo/packages/flecsolve/package.py
+++ b/spack-repo/packages/flecsolve/package.py
@@ -10,7 +10,7 @@ class Flecsolve(CMakePackage):
     homepage="https://github.com/lanl/flecsolve.git"
     git = "https://github.com/lanl/flecsolve.git"
     # TO DO update to stable when available
-    version("main", branch="flecsi-2.4")
+    version("main", branch="main")
 
     variant("tests", default=False, description="Enable unit tests")
     variant("standard", default=False, description="Standard setup for flecsolve")


### PR DESCRIPTION
Fixes #11.

The Spack package was trying to fetch `lanl/flecsolve` from branch `flecsi-2.4`, but that branch no longer exists. `main` is the available branch for the `main` package version.

Testing:
- `py -3.10 -m py_compile spack-repo/packages/flecsolve/package.py`
- `git ls-remote` confirms `main` exists and `flecsi-2.4` does not