### PR TITLE
Fix 2D/3D L1 error quadrature sampling only the diagonal

### DIFF
--- a/tools/test_verify_lib.py
+++ b/tools/test_verify_lib.py
@@ -1,0 +1,63 @@
+import unittest
+
+import numpy as np
+
+from verify_lib import compute_l1_error_fvm
+
+
+def cell_integral_power(bounds: list[tuple[float, float]]) -> float:
+    result = 1.0
+    for lower, upper in bounds:
+        result *= (upper**2 - lower**2) * 0.5
+    return result
+
+
+class ComputeL1ErrorFVMTest(unittest.TestCase):
+    def test_2d_uses_full_tensor_product_for_cell_integrals(self) -> None:
+        centers = np.array([0.25, 0.75])
+        xg, yg = np.meshgrid(centers, centers, indexing="ij")
+        x_num = np.array([xg.ravel(), yg.ravel()])
+
+        numerical = []
+        for x, y in zip(x_num[0], x_num[1]):
+            bounds = [
+                (x - 0.25, x + 0.25),
+                (y - 0.25, y + 0.25),
+            ]
+            numerical.append(cell_integral_power(bounds) / 0.25)
+
+        error = compute_l1_error_fvm(
+            x_num,
+            np.array(numerical),
+            lambda xy: xy[0] * xy[1],
+            2,
+        )
+
+        self.assertAlmostEqual(error, 0.0)
+
+    def test_3d_uses_full_tensor_product_for_cell_integrals(self) -> None:
+        centers = np.array([0.25, 0.75])
+        xg, yg, zg = np.meshgrid(centers, centers, centers, indexing="ij")
+        x_num = np.array([xg.ravel(), yg.ravel(), zg.ravel()])
+
+        numerical = []
+        for x, y, z in zip(x_num[0], x_num[1], x_num[2]):
+            bounds = [
+                (x - 0.25, x + 0.25),
+                (y - 0.25, y + 0.25),
+                (z - 0.25, z + 0.25),
+            ]
+            numerical.append(cell_integral_power(bounds) / 0.125)
+
+        error = compute_l1_error_fvm(
+            x_num,
+            np.array(numerical),
+            lambda xyz: xyz[0] * xyz[1] * xyz[2],
+            3,
+        )
+
+        self.assertAlmostEqual(error, 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_verify_lib.py
+++ b/tools/test_verify_lib.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 
-from verify_lib import compute_l1_error_fvm
+from verify_lib import compute_l1_error_fvm, simple_quad_2d, simple_quad_3d
 
 
 def cell_integral_power(bounds: list[tuple[float, float]]) -> float:
@@ -57,6 +57,30 @@ class ComputeL1ErrorFVMTest(unittest.TestCase):
         )
 
         self.assertAlmostEqual(error, 0.0)
+
+
+class SimpleQuadTensorProductTest(unittest.TestCase):
+    def test_2d_asymmetric_box_and_integrand(self) -> None:
+        got = simple_quad_2d(
+            lambda c: np.sin(c[0] + 2.0 * c[1]), 0.0, 1.0, 0.0, 2.0
+        )
+        expected = (np.sin(1.0) - np.sin(5.0) + np.sin(4.0)) * 0.5
+        self.assertAlmostEqual(got, expected)
+
+    def test_3d_asymmetric_box_and_integrand(self) -> None:
+        got = simple_quad_3d(
+            lambda c: np.sin(c[0] + 2.0 * c[1]) * np.exp(0.5 * c[2]),
+            0.0,
+            1.0,
+            0.0,
+            2.0,
+            0.0,
+            3.0,
+        )
+        expected = (np.sin(1.0) - np.sin(5.0) + np.sin(4.0)) * (
+            np.exp(1.5) - 1.0
+        )
+        self.assertAlmostEqual(got, expected)
 
 
 if __name__ == "__main__":

--- a/tools/verify_lib.py
+++ b/tools/verify_lib.py
@@ -94,6 +94,61 @@ def simple_quad(f: Callable, x0: NDArray, x1: NDArray, deg: int = 10) -> float:
     return np.sum(f(transform(points)) * weights) * 0.5 * (x1 - x0)
 
 
+def simple_quad_2d(
+    f: Callable, x0: float, x1: float, y0: float, y1: float, deg: int = 10
+) -> float:
+    """
+    Use a tensor-product Gauss-Legendre quadrature of degree deg
+    over the rectangle [x0, x1] x [y0, y1]
+    """
+
+    points, weights = np.polynomial.legendre.leggauss(deg)
+
+    xs = ((x1 - x0) * points + x1 + x0) * 0.5
+    ys = ((y1 - y0) * points + y1 + y0) * 0.5
+    xg, yg = np.meshgrid(xs, ys, indexing="ij")
+    wg = np.outer(weights, weights).ravel()
+
+    return (
+        np.sum(f([xg.ravel(), yg.ravel()]) * wg)
+        * 0.25
+        * (x1 - x0)
+        * (y1 - y0)
+    )
+
+
+def simple_quad_3d(
+    f: Callable,
+    x0: float,
+    x1: float,
+    y0: float,
+    y1: float,
+    z0: float,
+    z1: float,
+    deg: int = 10,
+) -> float:
+    """
+    Use a tensor-product Gauss-Legendre quadrature of degree deg
+    over the box [x0, x1] x [y0, y1] x [z0, z1]
+    """
+
+    points, weights = np.polynomial.legendre.leggauss(deg)
+
+    xs = ((x1 - x0) * points + x1 + x0) * 0.5
+    ys = ((y1 - y0) * points + y1 + y0) * 0.5
+    zs = ((z1 - z0) * points + z1 + z0) * 0.5
+    xg, yg, zg = np.meshgrid(xs, ys, zs, indexing="ij")
+    wg = np.outer(np.outer(weights, weights), weights).ravel()
+
+    return (
+        np.sum(f([xg.ravel(), yg.ravel(), zg.ravel()]) * wg)
+        * 0.125
+        * (x1 - x0)
+        * (y1 - y0)
+        * (z1 - z0)
+    )
+
+
 def get_dx(array: NDArray) -> float | None:
     """
     Get the minimum dx from array. Assume that the coordinates are ordered.
@@ -141,13 +196,7 @@ def compute_l1_error_fvm(
 
             error += abs(
                 dx * dy * numerical[i]
-                - simple_quad(
-                    lambda y: simple_quad(
-                        lambda x: analytical([x, y]), x0, x1
-                    ),
-                    y0,
-                    y1,
-                )
+                - simple_quad_2d(analytical, x0, x1, y0, y1)
             )
     else:
         dx = get_dx(x_num[0])
@@ -168,17 +217,7 @@ def compute_l1_error_fvm(
 
             error += abs(
                 dx * dy * dz * numerical[i]
-                - simple_quad(
-                    lambda z: simple_quad(
-                        lambda y: simple_quad(
-                            lambda x: analytical([x, y, z]), x0, x1
-                        ),
-                        y0,
-                        y1,
-                    ),
-                    z0,
-                    z1,
-                )
+                - simple_quad_3d(analytical, x0, x1, y0, y1, z0, z1)
             )
 
     return error


### PR DESCRIPTION
## Summary

This fixes the 2D and 3D L1 error calculation in `compute_l1_error_fvm`.

The old nested `simple_quad` calls passed whole quadrature-point arrays into the analytical function. In 2D and 3D that paired `x_i` with `y_i` and `z_i`, so the integral was sampled along the cell diagonal and then scaled by the weight sum.

For example, using the old path:

- `integral x*y dx dy` over `[0, 1]^2` gives `1/3`, but the correct value is `1/4`.
- `integral x*y*z dx dy dz` over `[0, 1]^3` gives `1/4`, but the correct value is `1/8`.

The patch adds explicit tensor-product Gauss-Legendre helpers for 2D and 3D and keeps the analytical callable contract the same: it still receives equal-length coordinate arrays.

## Checks

- Added `tools/test_verify_lib.py` with 2D and 3D exact-cell-average regression tests.
- `python tools/test_verify_lib.py`
- Reproduced the old diagonal-sampling values above.
- Checked the new helpers against exact 2D/3D polynomial integrals on asymmetric boxes.
- Checked `sin(x + y)` against its exact 2D integral.
- Checked an asymmetric 3D non-polynomial integral against a dense independent reference.
- Checked end-to-end 2D L1 error for exact cell averages: `0`.
- `git diff --check`
- `ruff check tools/verify_lib.py tools/test_verify_lib.py`