### PR TITLE
Use Python to combine verification output

### DIFF
--- a/tools/test_verify_output.py
+++ b/tools/test_verify_output.py
@@ -1,0 +1,24 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from verify_lib import find_last_output
+
+
+class FindLastOutputTest(unittest.TestCase):
+    def test_combines_csv_files_without_cat(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for rank in (0, 1):
+                for step in (1, 2):
+                    path = root / f"output-2D-{rank}-0000{step}.csv"
+                    path.write_text(f"rank{rank}\n")
+
+            output, combined = find_last_output(dir=directory)
+
+            self.assertTrue(combined)
+            self.assertEqual(Path(output).read_text(), "rank0\nrank1\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/verify_lib.py
+++ b/tools/verify_lib.py
@@ -1,7 +1,7 @@
 import argparse
 import glob
 import os
-import subprocess
+import shutil
 from collections.abc import Callable
 from importlib import util as imputil
 from typing import Any
@@ -216,8 +216,10 @@ def find_last_output(
 
         # Combine the files
         new_file = combine[-1].replace(f"D-{mm}-", f"D-{mm + 1}-")
-        with open(new_file, "w") as fwrite:
-            subprocess.run(["cat"] + combine, stdout=fwrite)
+        with open(new_file, "wb") as fwrite:
+            for file in combine:
+                with open(file, "rb") as fread:
+                    shutil.copyfileobj(fread, fwrite)
         return new_file, True
 
 

--- a/tools/verify_lib.py
+++ b/tools/verify_lib.py
@@ -219,7 +219,7 @@ def find_last_output(
         with open(new_file, "wb") as fwrite:
             for file in combine:
                 with open(file, "rb") as fread:
-                    shutil.copyfileobj(fread, fwrite)
+                    shutil.copyfileobj(fread, fwrite, length=1024 * 1024)
         return new_file, True
 
 


### PR DESCRIPTION
## Change

`find_last_output` used `cat` to merge rank CSV files. This now uses Python file I/O, with the existing output order unchanged.

## Checks

- `python tools/test_verify_output.py`
- `ruff check tools`
- Python compile checks
- codespell on changed files
- local Sphinx build
- GitHub documentation CI
- `git diff --check`

CMake and C++ unit tests were not run locally because CMake and FleCSI are not installed here.

Closes #15
